### PR TITLE
Using maxheap for heapsort

### DIFF
--- a/sortingAlgo/heapSort/heapSort.rs
+++ b/sortingAlgo/heapSort/heapSort.rs
@@ -11,7 +11,7 @@ where
     fn new() -> Self {
         Heap {
             array: [T::default(); 32],
-            is_minheap: true,
+            is_minheap: false,
             size: 0,
         }
     }
@@ -84,7 +84,7 @@ fn build<T: PartialOrd + Copy + Default>(array: [T; 32], n: usize) -> Heap<T> {
 fn heapsort<T: PartialOrd + Copy + Default>(array: [T; 32], n: usize) -> [T; 32] {
     let mut heap = build(array, n);
     let mut arr: [T; 32] = [T::default(); 32];
-    for i in 0..n {
+    for i in (0..n).rev() {
         arr[i] = heap.extract();
     }
 


### PR DESCRIPTION
This is a fix of Heapsort algorithm implement in Rust [ merged in #130 ]
---
Following [¹] heapsort algorithm must be implemented with a max heap, so
I fixed struct using max heap and extract in reverse way.

[¹] https://en.wikipedia.org/wiki/Heapsort